### PR TITLE
mesa: fix error value in GetFramebufferAttachmentParameteriv for OpenGL ...

### DIFF
--- a/src/mesa/main/fbobject.c
+++ b/src/mesa/main/fbobject.c
@@ -2766,7 +2766,7 @@ _mesa_GetFramebufferAttachmentParameteriv(GLenum target, GLenum attachment,
 
       if (_mesa_is_gles3(ctx) && attachment != GL_BACK &&
           attachment != GL_DEPTH && attachment != GL_STENCIL) {
-         _mesa_error(ctx, GL_INVALID_OPERATION,
+         _mesa_error(ctx, GL_INVALID_ENUM,
                      "glGetFramebufferAttachmentParameteriv(attachment)");
          return;
       }


### PR DESCRIPTION
...ES 3.0

Section 6.1.13 "Framebuffer Object Queries" of OpenGL ES 3.0 spec:

 "If the default framebuffer is bound to target, then attachment must be
  BACK, identifying the color buffer; DEPTH, identifying the depth buffer; or
  STENCIL, identifying the stencil buffer."

But the spec doesn't state which kind of error to return. GL_EXT_draw_buffers,
section "Errors" says the following:

  "The INVALID_ENUM error is generated by GetFramebufferAttachmentParameteriv
   if the <attachment> parameter is not one of the values listed in Table 4.x."

Due to the ambiguity of OpenGL ES 3.0 spec on this regard and because
GL_EXT_draw_buffers returns INVALID_ENUM in a related case, then
change the returned error to INVALID_ENUM.

More info:

http://lists.freedesktop.org/archives/mesa-dev/2015-January/074447.html

Fixes:

dEQP-GLES3.functional.fbo.api.attachment_query_default_fbo

Signed-off-by: Samuel Iglesias Gonsalvez siglesias@igalia.com
